### PR TITLE
Update name to use UniversalScalableFirmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,41 @@
 # Introduction
 
-Welcome to the Universal Payload project. The goal of this project is to define an interface between a first stage platform initialization bootloader and a second stage payload.
+Welcome to the Universal Scalable Firmware project. The goal of this project is to define an interface between a first stage platform initialization bootloader and a second stage payload.
 
 ## Specification
  
 The interface specification is at 
-https://universalpayload.github.io/documentation/
+https://universalscalablefirmware.github.io/documentation/
 
 The specification source is maintained in restructured text format and is available at 
-https://github.com/universalpayload/documentation
+https://github.com/UniversalScalableFirmware/documentation
 
 ## Sandboxes
 
-A few example implementations of the Universal Payload specification are available.
+A few example implementations of the Universal Scalable Firmware payload specification are available.
 
 ### Slim Bootloader
 
-An POC implementation of Slim Bootloader conforming to the Universal Payload specification
-https://github.com/universalpayload/slimbootloader/tree/universal_payload
+An POC implementation of Slim Bootloader conforming to the Universal Scalable Firmware Payload specification
+https://github.com/UniversalScalableFirmware/slimbootloader/tree/universal_payload
 
 ### coreboot
 
-An POC implementation of coreboot conforming to the Universal Payload specification
-https://github.com/universalpayload/coreboot/tree/universal_payload
+An POC implementation of coreboot conforming to the Universal Scalable Firmware Payload specification
+https://github.com/UniversalScalableFirmware/coreboot/tree/universal_payload
 
 ### UEFI Payload
 
-An POC implementation of UEFI Payload conforming to universal payload specification.
-https://github.com/universalpayload/edk2/tree/universal_payload
+An POC implementation of UEFI Payload conforming to Universal Scalable Firmware Payload specification.
+https://github.com/UniversalScalableFirmware/edk2/tree/universal_payload
 
 ### Linux Payload
 
-An POC implementation of Linux Payload containing necessary patches to build a basic Linux payload conforming to the universal payload specification.
-https://github.com/universalpayload/linuxpayload
+An POC implementation of Linux Payload containing necessary patches to build a basic Linux payload conforming to the Universal Scalable Firmware Payload specification.
+https://github.com/UniversalScalableFirmware/linuxpayload
 
 ### Tools
 
-The pack_payload.py tool can be used to pack a normal payload image into the universal payload image format
+The pack_payload.py tool can be used to pack a normal payload image into the Universal Scalable Firmware Payload image format
 The clone_and_build_sbl_with_uefipayload.py tool could clone and build SBL + UEFI payload to have a quick try.
-https://github.com/universalpayload/tools
+https://github.com/UniversalScalableFirmware/tools


### PR DESCRIPTION
Universal payload is part of UniversalScalableFirmware.
So update the name to use the formal name.

Signed-off-by: Guo Dong <guo.dong@intel.com>